### PR TITLE
Add len2weight tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ __pycache__
 notebooks
 results
 *.ipynb_checkpoints
+.pytest_cache
 eval_results
-tests
 .DS_Store
 gradio.sh

--- a/README.md
+++ b/README.md
@@ -149,8 +149,15 @@ You can replace the variables in the script with your own before running.
 See [TRAIN](TRAIN.md) for more details.
 
 ### Eval
-We provide the scripts for evaluating VLM, T2I and Editing benchmarks. 
+We provide the scripts for evaluating VLM, T2I and Editing benchmarks.
 Please See [EVAL](EVAL.md) for more details.
+
+### Tests
+Run the unit tests with [pytest](https://docs.pytest.org/):
+
+```bash
+pytest
+```
 
 
 ## 📊 Benchmarks

--- a/tests/test_len2weight.py
+++ b/tests/test_len2weight.py
@@ -1,0 +1,48 @@
+import sys
+from pathlib import Path
+import types
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+# Provide minimal stubs for heavy optional dependencies
+torch_stub = types.ModuleType("torch")
+torch_nn_stub = types.ModuleType("torch.nn")
+torch_nn_attention_stub = types.ModuleType("torch.nn.attention")
+flex_attention_stub = types.ModuleType("torch.nn.attention.flex_attention")
+flex_attention_stub.or_masks = lambda *a, **k: None
+flex_attention_stub.and_masks = lambda *a, **k: None
+torch_nn_attention_stub.flex_attention = flex_attention_stub
+torch_stub.nn = types.ModuleType("torch.nn")
+torch_stub.nn.attention = torch_nn_attention_stub
+sys.modules.setdefault("torch", torch_stub)
+sys.modules.setdefault("torch.nn", torch_stub.nn)
+sys.modules.setdefault("torch.nn.attention", torch_nn_attention_stub)
+sys.modules.setdefault(
+    "torch.nn.attention.flex_attention", flex_attention_stub
+)
+
+from data.data_utils import len2weight
+
+@pytest.mark.parametrize(
+    "loss_reduction,x,expected",
+    [
+        ("token", 5, 1.0),
+        ("sample", 5, 1/5),
+        ("square", 4, 1/(4 ** 0.5)),
+    ],
+)
+def test_len2weight_values(loss_reduction, x, expected):
+    assert len2weight(x, loss_reduction) == pytest.approx(expected)
+
+@pytest.mark.parametrize("loss_reduction", ["token", "sample", "square"])
+def test_len2weight_zero(loss_reduction):
+    assert len2weight(0, loss_reduction) == 0
+
+
+def test_len2weight_invalid():
+    with pytest.raises(NotImplementedError):
+        len2weight(1, "unknown")
+


### PR DESCRIPTION
## Summary
- create `tests/test_len2weight.py`
- mention running tests with pytest in the README
- adjust `.gitignore` to keep pytest cache out and track tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68402b8298888321beca7096b7fd861b 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request adds a new test file for the len2weight function, ensuring its accuracy across various loss reduction modes. It also updates the README with pytest instructions and modifies the .gitignore to exclude pytest cache files, enhancing both testing and documentation.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>